### PR TITLE
feat(rooms): add force-end game button for room owner

### DIFF
--- a/src/entities/game/game.ts
+++ b/src/entities/game/game.ts
@@ -352,6 +352,20 @@ export class Game {
 		}
 	}
 
+	public async forceEnd (): Promise<void> {
+		this.ended = dayjs();
+
+		logGameEvent({
+			type: 'GAME_ENDED',
+			gameId: this.id,
+			roomId: this.roomId,
+			winnerId: this.determineWinner(),
+			duration: this.ended.diff(this.started, 'ms'),
+		});
+
+		await this.save();
+	}
+
 	private determineWinner (): PlayerId {
 		const scores = this.allPlayers.map(id => ({
 			id,

--- a/src/modules/rooms/handlers.ts
+++ b/src/modules/rooms/handlers.ts
@@ -1,7 +1,7 @@
 import { BOT, logGameEvent } from '~/core';
 import { ORM } from '~/db';
 import { Game } from '~/entities/game';
-import { sendFirstMessage } from '~/entities/game/services';
+import { sendFirstMessage, notifyEndGameMessage } from '~/entities/game/services';
 import { escapeHtml } from '~/shared/lib';
 import { getAthanasiusesListText, MIN_PLAYERS_TO_START, txt as gameTxt } from '~/shared/ui/game';
 import { getCallbackMeta } from '~/core/lib';
@@ -269,6 +269,41 @@ export const gameSendTurnMessageCallbackHandler = async (ctx: CallbackCtx) => {
 	await sendFirstMessage(game, sender);
 	await ctx.editMessageText(
 		`${utils.getRoomBaseText(room, true)}\n\n${gameTxt.gameMessageResendSuccess}`,
+		{ reply_markup: utils.getRoomInlineKeyboard(ctx.from.id, room) },
+	);
+};
+
+export const gameForceEndCallbackHandler = async (ctx: CallbackCtx) => {
+	await ctx.answerCallbackQuery();
+
+	const room = utils.getRoomFromMeta(ctx);
+
+	if (!await utils.ensureRoomMember(ctx, room)) {
+		return;
+	}
+
+	if (!await utils.ensureRoomOwner(ctx, room)) {
+		return;
+	}
+
+	const activeGameSchema = ORM.Games.getActive(room.id);
+
+	if (!activeGameSchema) {
+		await ctx.editMessageText(
+			utils.getRoomBaseText(room),
+			{ reply_markup: utils.getRoomInlineKeyboard(ctx.from.id, room) },
+		);
+		return;
+	}
+
+	const game = new Game({ id: activeGameSchema.id });
+	const sender = BOT.api.sendMessage.bind(BOT.api);
+
+	await game.forceEnd();
+	await notifyEndGameMessage(game, sender);
+
+	await ctx.editMessageText(
+		utils.getRoomBaseText(room) + `\n\n${ui.txt.gameForceEnded}`,
 		{ reply_markup: utils.getRoomInlineKeyboard(ctx.from.id, room) },
 	);
 };

--- a/src/modules/rooms/index.ts
+++ b/src/modules/rooms/index.ts
@@ -40,6 +40,7 @@ registered.callbackQuery(/^room:delete:/, handlers.deleteRoomCallbackHandler);
 registered.callbackQuery(/^room:getath:/, handlers.gameGetAthanasiusesCallbackHandler);
 registered.callbackQuery(/^room:whoseturn:/, handlers.gameWhoseTurnCallbackHandler);
 registered.callbackQuery(/^room:sendturnmsg:/, handlers.gameSendTurnMessageCallbackHandler);
+registered.callbackQuery(/^room:endgame:/, handlers.gameForceEndCallbackHandler);
 registered.callbackQuery(/^rooms:back:/, handlers.backCallbackHandler);
 registered.callbackQuery(/^room:settings:/, SettingsHandlers.start);
 registered.callbackQuery(/^room:cjc:/, SettingsHandlers.changeJoinCode);

--- a/src/modules/rooms/ui.ts
+++ b/src/modules/rooms/ui.ts
@@ -22,6 +22,7 @@ export const txt = {
 	ownerCannotLeave: 'Владелец комнаты не может выйти из своей комнаты',
 	cannotKickOwner: 'Нельзя выгнать владельца комнаты',
 	roomDeleted: 'Комната удалена',
+	gameForceEnded: 'Игра завершена досрочно',
 } as const;
 
 /* DEFAULT KEYBOARD */

--- a/src/modules/rooms/utils.ts
+++ b/src/modules/rooms/utils.ts
@@ -97,6 +97,8 @@ export const getRoomInlineKeyboard = (meId: number, room: RoomSchema) => {
 		if (room.owner === meId) {
 			keyboard.text('Отправить сообщение хода', stringifyCallbackData({ module: 'room', action: 'sendturnmsg', meta: room.id }));
 			keyboard.row();
+			keyboard.text('Завершить игру', stringifyCallbackData({ module: 'room', action: 'endgame', meta: room.id }));
+			keyboard.row();
 		}
 	} else {
 		if (room.owner === meId) {

--- a/tests/modules/rooms.ts
+++ b/tests/modules/rooms.ts
@@ -852,4 +852,47 @@ describe('rooms', async () => {
 		assertSent(log, ALICE.id, 'Нельзя удалить комнату с активной игрой');
 		assert(ORM.Rooms.getAll().find(r => r.id === room.id) !== undefined, 'Room with active game should not be deleted');
 	});
+
+	it('Owner can force-end an active game, all players notified', async () => {
+		const room = await setupRoomWithPlayers([BOB, CAROL], handlers);
+		await handlers.gameStartCallbackHandler(makeCallbackCtx(ALICE, { module: 'room', action: 'start', meta: room.id }));
+		resetLog();
+
+		await handlers.gameForceEndCallbackHandler(makeCallbackCtx(ALICE, { module: 'room', action: 'endgame', meta: room.id }));
+		const log = getLog();
+
+		const game = DB.data.games.find(g => g.roomId === room.id);
+		assert(game !== undefined, 'Game should still exist in DB after force-end');
+		assert(game!.ended !== undefined, 'Game should have ended timestamp after force-end');
+
+		[ALICE, BOB, CAROL].forEach(player => {
+			assertSent(log, player.id, 'Игра закончилась!');
+		});
+		assertSent(log, ALICE.id, roomTxt.gameForceEnded);
+	});
+
+	it('Non-owner cannot force-end an active game', async () => {
+		const room = await setupRoomWithPlayers([BOB, CAROL], handlers);
+		await handlers.gameStartCallbackHandler(makeCallbackCtx(ALICE, { module: 'room', action: 'start', meta: room.id }));
+		resetLog();
+
+		await handlers.gameForceEndCallbackHandler(makeCallbackCtx(BOB, { module: 'room', action: 'endgame', meta: room.id }));
+		const log = getLog();
+
+		const game = DB.data.games.find(g => g.roomId === room.id);
+		assert(game?.ended === undefined, 'Game should not end when non-owner calls force-end');
+		assertSent(log, BOB.id, roomTxt.ownerOnly);
+	});
+
+	it('Active room keyboard shows force-end button only for owner when game is active', async () => {
+		const room = await seedActiveRoom({ allowMailing: false });
+		resetLog();
+
+		await handlers.openRoomCallbackHandler(makeCallbackCtx(ALICE, { module: 'rooms', action: 'open', meta: room.id }));
+		assertKeyboardButton(getLog(), ALICE.id, 'Завершить игру', `room:endgame:${room.id}`);
+		resetLog();
+
+		await handlers.openRoomCallbackHandler(makeCallbackCtx(BOB, { module: 'rooms', action: 'open', meta: room.id }));
+		assertNotSent(getLog(), BOB.id, 'Завершить игру');
+	});
 });


### PR DESCRIPTION
Adds an inline "Завершить игру" button in the active room menu visible only to the room owner. Triggers Game.forceEnd(), which marks the game as ended, logs GAME_ENDED, and sends the final summary to all players.